### PR TITLE
update documentation

### DIFF
--- a/docs/about.md
+++ b/docs/about.md
@@ -8,8 +8,27 @@ ZettelGeist is a plaintext note-taking system, inspired by the [ZettelKasten Met
 
 The project founders have both been interested in taking notes long before discovering ZettelKasten. We really like the thought process behind ZettelKasten, however, and think it is ahead of its time by being "less is more" in its focus.
 
-A key, salient feature of our approach to implementing a ZettelKasten system is *not* to get distracted by GUI tools at an early stage of development. The default assumption of our system is that we work from plaintext files. We are particularly inspired by systems like Jekyll (a static-site generator for building web sites) that uses YAML to organize its front matter and Markdown as the body. We're even starting more simply by just using YAML without Markdown, although we might introduce it at release time. The idea is to focus on true notetaking by not encouraging the writing of large, complex documents (which aren't really notes, right??)
+ZettelGeist implements the *spirit* of ZettelKasten; the key feature of our approach is to work from plaintext files.
+We are inspired by [pandoc](https://pandoc.org/) and [Jekyll](https://jekyllrb.com/), systems that employ Markdown and YAML to create elegant and intricately structured documents.
+We are starting even more simply by using YAML alone, without Markdown.
+Most visitors to this site will know that [YAML](https://en.wikipedia.org/wiki/YAML) is a computer-readable data format designed to be maximally legible to humans.
+These features make YAML a perfect format for note-taking.
 
-So ZettelGeist is aimed at supporting the *spirit* of ZettelKasten, while ensuring that it will be useful in other domains. Our primary audience is the scholar who wants to write notes using a simple text editor and storing these notes in the cloud, e.g. in Dropbox, GitHub, etc. While we'd love to build something like the successor to Evernote or OneNote--even as a graphical client--our view is that no such tool should be developed without having the right core abstractions in place. Ultimately, the *note* is the central abstraction. Having support for metadata is crucial, especially for scholarly--or other serious--projects.
+Suppose you want to do the following:
 
-Stay tuned!!
+- Follow the traditional and ever-valid methods of scholarly note-taking: write research note-cards with a **title**, some **keywords**, a **quotation** (with optional **comment** or **summary**), and **bibliographical citation** (such as the book or article title and page number).  
+
+- Store your research notes safely and sustainably.
+
+- Retrieve and browse notes on a particular topic.
+
+- Pull and organize notes to be used in writing a scholarly book or article.
+
+Best practices for these research activities were developed and refined long before the advent of personal computers.
+ZettelGeist merges the traditional techniques into the computer world.
+This application is the missing link between applications for managing bibliography ([Zotero](https://www.zotero.org/) is our favorite) and [plain-text workflows for scholarly writing](https://pandoc.org/MANUAL.html#citations).
+
+First-time visitors should read our statement on [Note Format](/thenote) and instructions for [installation](/install).
+Proceed from there to the [User's Guide](/gs).
+
+New to the world of plaintext writing? Start with our [GDocs Tutorial](/tutorial-GDocs). 

--- a/docs/gs.md
+++ b/docs/gs.md
@@ -4,18 +4,20 @@ title: User's Guide
 permalink: /gs/
 ---
 
+# Summary
+
 ZettelGeist performs two basic operations: writing note cards and retrieving them.
 The tool for writing cards is `zettel`.
-Since cards are stored as [`yaml` documents](https://en.wikipedia.org/wiki/YAML), `zettel` is essentially a command-line tool for writing new `yaml` documents and editing existing ones.
+Since cards are stored as [`yaml`](https://en.wikipedia.org/wiki/YAML), `zettel` is essentially a command-line tool for writing new `yaml` documents and editing existing ones.
 The functionality of this tool will be illustrated first.
 We will turn then to `zcreate`, `zimport`, and `zfind`, the tools for collecting cards into a database and running queries on it.
 
 # Prerequisites
 
-This tutorial assumes that you have installed ZettelGeist and confirmed its tools are available in a Python virtual environment.
+This user's guide assumes that you have installed ZettelGeist and confirmed its tools are available in a Python virtual environment.
 See the [Installation](/install) page for instructions. 
-You must source the virtualenv to use ZettelGeist.
-We will assume that your virtualenv is named `zenv`.
+You must source the virtual environment to use ZettelGeist.
+We will assume that your virtual environment is named `zenv`.
 
 # Writing cards with `zettel`
 
@@ -33,7 +35,7 @@ For output to a file, use the option `--save` (to write the filename yourself) o
 (zenv) $ zettel --help
 ```
 
-Most options have a regular verb-object syntax and instruct `zettel` to do a specified operation (`set`, `append`, `prompt`, `load` or `delete`) on the specified field.
+Most options have a regular verb-object syntax and instruct `zettel` to do a specified action (`set`, `append`, `prompt`, `load` or `delete`) on a field-value.
 Examples will be given below.
 
 ## Create and save a simple zettel
@@ -69,7 +71,7 @@ note: A Zettel with a note
 ```
 
 Writing long strings in command line arguments is inconvenient, so ZettelGeist provides two alternatives.
-The option `--prompt-<FIELD>` divides note-card creation into steps.
+The option `--prompt-<FIELD>` divides card-writing into steps.
 When this option is invoked, `zettel` will request input for the specified field before creating a new card.
 Text is entered within the terminal.
 Newlines and blank lines are permitted.
@@ -98,10 +100,10 @@ To serialize cards rather assigning a timestamp to them, use the `--counter` opt
 (zenv) $ zettel --file template.yaml --id tutorial --counter tutorial --name id counter
 ```
 
-This command initiates a count of cards with the `id` 'tutorial'.
-The default number of digits is four;
-the count is maintained in a new binary file `.counter.dat`.
-The values `id`, `counter`, and `timestamp` can be combined in any order.
+This command initiates a count of cards with the `id` "tutorial".
+The count is maintained in a new binary file `.counter.dat`.
+The default number of digits is four and the count starts at `0000`.
+The values `id`, `counter`, and `timestamp` may be combined in any order.
 
 ## ZettelGeist fields
 
@@ -149,7 +151,7 @@ When calling a template card with the `--file` option, the following syntax will
 --set-cite "" "pp. 103-4"
 ```
 
-This command retains the `bibkey` value in the input file but replaces the previous `page` value with "pp. 1-2".
+This command retains the `bibkey` value in the input file but replaces the previous `page` value with "pp. 103-4".
 
 ### `comment`
 
@@ -161,10 +163,23 @@ Any comment you want to make about the zettel in general.
 A `year` (string) and `era` (string) as a nested dictionary.
 Syntax follows `cite`.
 
-### `title`
+### `mentions`
+
+(List.)
+One or more mentions.
+Use the option `--append-mentions` and put each within quotes. 
+For instance: `--append-mentions "Sievers, Eduard" "Lachmann, Karl"`.
+
+### `note`
+
 (String.)
-A human-readable title for a sequence of note cards. 
-We set this title in the template card for a source and retain it in all note cards on that source.
+This is the core element of the note card.
+Usually it is a quotation extracted from the source and page identified in the `cite` field.
+
+### `summary`
+
+(String.)
+A concise summary of the note (by convention).
 
 ### `tags`
 
@@ -173,22 +188,10 @@ One or more keywords.
 Use the option `--append-tags` and put each keyword within quotes. 
 For instance: `--append-tags "Charles Babbage" "Ada Lovelace" "Victorian Era"`.
 
-### `mentions`
-
-(List.)
-One or more mentions.
-Syntax follows `tags`.
-
-### `summary`
-
+### `title`
 (String.)
-A concise summary of the note (by convention).
-
-### `note`
-
-(String.)
-This is the core element of the note card.
-Usually it is a quotation extracted from the source and page identified in the `cite` field.
+A human-readable label for a sequence of note cards. 
+We set this label in the template card for a source and retain it in all note cards on that source.
 
 ### `url`
 
@@ -197,7 +200,6 @@ Useful for bookmarking websites.
 
 # Retrieving cards
 
-The previous section has described `zettel`, the ZettelGeist tool for writing note cards.
 We now describe tools for selectively retrieving cards.
 `zcreate` creates a new empty database.
 `zimport` populates the database with note cards.
@@ -254,7 +256,7 @@ cite:
   page: web page
 ```
 
-### Creating a database
+### Create a database
 
 We will now import the cards into a database.
 First, create a new database: 
@@ -272,7 +274,7 @@ Next, populate the database:
 
 We are now ready to run queries on the database and selectively retrieve cards from it.
 
-## Running queries
+### Run queries
 
 Searching is done with the `zfind` tool.
 The option `--query-string` tells `zfind` what to look for.
@@ -281,7 +283,7 @@ The options `--count` and `--show-<FIELD>` tell `zfind` what to do with matches:
 - `--count` counts the cards matching the search criteria and prints that number to standard output.
 - `--show-<FIELD>` prints the specified field to standard output.
 
-These output options may be combined. `--show-<FIELD>` can be repeated with different fields.
+These output options may be combined. `--show-<FIELD>` may be repeated with different fields.
 
 The basic syntax of `--query-string` is `'KEY:"VALUE"'`.
 This syntax is illustrated in the following examples: 
@@ -355,12 +357,24 @@ summary: Kansas City Royals
 (zenv) $ zfind --database mlb.db --query-string 'note:"Cubs"' --show-note
 
 note: |
-  The Chicago Cubs are an American professional baseball team based in Chicago, Illinois. The Cubs compete in Major League Baseball (MLB) as a member club of the National League (NL) Central division, where they are the defending World Series champions. The team plays its home games at Wrigley Field, located on the city's North Side. The Cubs are one of two major league teams in Chicago; the other, the Chicago White Sox, is a member of the American League (AL) Central division. The Cubs, first known as the White Stockings, was a founding member of the NL in 1876, becoming the Chicago Cubs in 1903.[2] The Cubs have appeared in a total of eleven World Series. The 1906 Cubs won 116 games, finishing 116–36 and posting a modern-era record winning percentage of .763, before losing the World Series to the Chicago White Sox by four games to two. The Cubs won back-to-back World Series championships in 1907 and 1908, becoming the first major league team to play in three consecutive World Series, and the first to win it twice. Most recently, the Cubs won the 2016 National League Championship Series and 2016 World Series, which ended a 71-year National League pennant drought and a 108-year World Series championship drought,
+  The Chicago Cubs are an American professional baseball team based in Chicago, Illinois. The Cubs
+  compete in Major League Baseball (MLB) as a member club of the National League (NL) Central
+  division, where they are the defending World Series champions. The team plays its home games at
+  Wrigley Field, located on the city's North Side. The Cubs are one of two major league teams in
+  Chicago; the other, the Chicago White Sox, is a member of the American League (AL) Central
+  division. The Cubs, first known as the White Stockings, was a founding member of the NL in 1876,
+  becoming the Chicago Cubs in 1903.[2] The Cubs have appeared in a total of eleven World Series.
+  The 1906 Cubs won 116 games, finishing 116–36 and posting a modern-era record winning percentage
+  of .763, before losing the World Series to the Chicago White Sox by four games to two. The Cubs
+  won back-to-back World Series championships in 1907 and 1908, becoming the first major league
+  team to play in three consecutive World Series, and the first to win it twice. Most recently,
+  the Cubs won the 2016 National League Championship Series and 2016 World Series, which ended a
+  71-year National League pennant drought and a 108-year World Series championship drought,
 
 ---
 ```
 
-To save this output, redirect it from standard output to a file with `>`: 
+To save this output, redirect standard output to a file with `>`: 
 
 ```shell
 (zenv) $ zfind --database mlb.db --query-string 'note:"Cubs"' --show-note > new-file.txt

--- a/docs/gs.md
+++ b/docs/gs.md
@@ -23,11 +23,11 @@ We will assume that your virtual environment is named `zenv`.
 
 ## Synopsis
 
-`zettel` [--file *input-file*] \[*options*] ...
+`zettel` [`--file` *INPUT-FILE*] \[*OPTIONS*] [`--save` *OUTPUT-FILE* | `--name` *ARGUMENT...*]
 
 If no input file is specified, input is read from the options passed to `zettel` in standard input.
 Output goes by default to standard output.
-For output to a file, use the option `--save` (to write the filename yourself) or `--name` (to have `zettel` write the filename for you).
+For output to a file, use `--save` (to write the filename yourself) or `--name` (to have `zettel` write the filename for you).
 
 ## Getting help
 
@@ -207,11 +207,14 @@ We now describe tools for selectively retrieving cards.
 
 ## Synopsis
 
-```zcreate --database <NAME>.db```
+`zcreate --database` *NAME*`.db`
 
-```zimport --database <NAME>.db --dir $(pwd)```
+`zimport --database` *NAME*`.db --dir $(pwd)`
 
-```zfind --database <NAME>.db  --query-string 'FIELD:"VALUE"' ``` [*options*]
+`zfind --database` *NAME*`.db  --query-string '`*FIELD*`:"`*VALUE*`" [& | ! `*FIELD*`:"`*VALUE*`"]...' ` [*OPTIONS*]
+
+With `zfind`, multiple search criteria are concatenated with the operators `& | !` (respectively AND, OR, NOT).
+At least one option is required, telling `zfind` what to do with matches.
 
 ## A tutorial
 

--- a/docs/gs.md
+++ b/docs/gs.md
@@ -1,170 +1,237 @@
 ---
 layout: page
-title: Getting Started
+title: User's Guide
 permalink: /gs/
 ---
 
-## Prerequisites
+ZettelGeist performs two basic operations: writing note cards and retrieving them.
+The tool for writing cards is `zettel`.
+Since cards are stored as [`yaml` documents](https://en.wikipedia.org/wiki/YAML), `zettel` is essentially a command-line tool for writing new `yaml` documents and editing existing ones.
+The functionality of this tool will be illustrated first.
+We will turn then to `zcreate`, `zimport`, and `zfind`, the tools for collecting cards into a database and running queries on it.
 
-Please visit the [Installation](/install) before starting the tutorial. This tutorial assumes you have installed 
-ZettelGeist and have confirmed that the tools are available in a Python virtualenv.
+# Prerequisites
 
-We assume that your virtualenv is named `zenv` here. Wherever you see `zenv` here, your setup can be different, as long
-as you completed the installation and verified that it is nominally functioning.
+This tutorial assumes that you have installed ZettelGeist and confirmed its tools are available in a Python virtual environment.
+See the [Installation](/install) page for instructions. 
+You must source the virtualenv to use ZettelGeist.
+We will assume that your virtualenv is named `zenv`.
 
-This tutorial also depends on sample files, provided at https://github.com/ZettelGeist/zg-tutorial.  You can visit this
-page to download the examples, or you can use `git` to fetch it:
+# Writing cards with `zettel`
+
+## Synopsis
+
+`zettel` [--file *input-file*] \[*options*] ...
+
+If no input file is specified, input is read from the options passed to `zettel` in standard input.
+Output goes by default to standard output.
+For output to a file, use the option `--save` (to write the filename yourself) or `--name` (to have `zettel` write the filename for you).
+
+## Getting help
 
 ```shell
-git clone https://github.com/ZettelGeist/zg-tutorial.git
+(zenv) $ zettel --help
 ```
 
-This will create the folder `zg-tutorial`, which we'll reference in this tutorial.
+Most options have a regular verb-object syntax and instruct `zettel` to do a specified operation (`set`, `append`, `prompt`, `load` or `delete`) on the specified field.
+Examples will be given below.
 
-## Creating Zettels
-
-The `zettel` command is used to create zettels. You can also create zettels using an ordinary text editor.
-
-### Getting help
+## Create and save a simple zettel
 
 ```shell
-zettel --help
-```
-
-The help shows what at first glance appears to be a bewildering number of options. However, most of the options are *the same* and are just
-being used to do an operation (set, delete, append, etc.) on any given field.
-
-### Create a simple zettel
-
-```shell
-zettel --set-title "My First Zettel"
+(zenv) $ zettel --set-title "Hello, World!"
 ```
 
 This results in the following output:
 
 ```yaml
-title: My First Zettel
+title: Hello, World!
 ```
 
-### Create zettel with multiple fields
-
-A zettel can have as few fields as you wish, including zero. However, a zettel only becomes interesting as you add more information. Let's add a *summary* and a *note*.
+To write this output to a file, invoke the `--save` option:
 
 ```shell
-zettel --set-title "My First Zettel" --set-summary "A Zettel with a note" --set-note "Line 1\nLine 2\nLine 3"
+(zenv) $ zettel --set-title "Hello, World!" --save template.yaml
 ```
 
-This results in
+A basic ZettelGeist workflow consists in writing a template-card to be invoked and edited in subsequent iterations.
+Here is an example: 
+
+```shell
+(zenv) $ zettel --file template.yaml --set-note "A Zettel with a note" --name timestamp
+```
+
+This command reads two input sources, merges them, and saves output to a new file with the following content:
 
 ```yaml
-title: My First Zettel
-summary: A Zettel with a note
-note: |-
-  Line 1
-  Line 2
-  Line 3
+title: Hello, World!
+note: A Zettel with a note
 ```
 
-When setting a field to a string value as we have done for each of these fields, it is permitted to have *embedded newlines* anywhere you like. For the note we have written, we have three input lines, each of which appears on a separate line.
-
-YAML (the format in which Zettels are stored) provides excellent support for this concept and will take your text and indent it using a multiline string. As long as each line is indented consistently relative to the *note* key, it will be valid.
-
-Obviously, writing longer strings using the command line is sometimes impractical, so we created two ways of being able to do this easily: prompting for input (using the `--prompt-<FIELD>` options) or by loading the plaintext from a file (using `--load-<FIELD>`). Each of these is easy to demonstrate.
-
-Let's try loading some text by having `zettel` prompt for it. We'll modify the above command as follows:
+Writing long strings in command line arguments is inconvenient, so ZettelGeist provides two alternatives.
+The option `--prompt-<FIELD>` divides note-card creation into steps.
+When this option is invoked, `zettel` will request input for the specified field before creating a new card.
+Text is entered within the terminal.
+Newlines and blank lines are permitted.
+Type `ctrl+d` to complete input.
 
 ```shell
-zettel --set-title "My First Zettel" --set-summary "A Zettel with a note" --prompt-note
+(zenv) $ zettel --file template.yaml --prompt-note --name timestamp
 ```
 
-```
-Enter text for note. ctrl-d to end.
-note> Line 1
-note> Line 2
-note> Line 3
-note>
-note> Even a blank line is allowed.
-note>
-```
-
-Results
-
-```yaml
-title: My First Zettel
-summary: A Zettel with a note
-note: |-
-  Line 1
-  Line 2
-  Line 3
-
-  Even a blank line is allowed.
-```
-
-
-### Load field from another file
-
-TODO
-
-## Indexing Zettels for Search
-
-For this section, we provide you with access to some sample zettels. These can be found in the ZettelGeist tutorial repository
-at https://github.com/ZettelGeist/zg-tutorial.git. (See Prerequisites above.)
-
-You can be in any folder while trying this, but we'll assume you are in the `zettelgeist\docs` after performing an initial clone of our repository.
+The option `--load-<FIELD>` reads input for the specified field from a text file:
 
 ```shell
-$ cd zg-tutorial
-$ zcreate --database mlb.db
-Creating new database mlb.db
+(zenv) $ zettel --file template.yaml --load-note some.txt --name timestamp
 ```
 
+The `timestamp` value ensures that no two cards will have the same file name, but it masks file content.
+The `--id` option feeds a descriptive string into the file name:
 
 ```shell
-$ ls zettels/baseball
-ls zettels/baseball
-arizona-diamondbacks.yaml  milwaukee-brewers.yaml
-atlanta-braves.yaml        minnesota-twins.yaml
-baltimore-orioles.yaml     new-york-mets.yaml
-boston-red-sox.yaml        new-york-yankees.yaml
-chicago-cubs.yaml          oakland-athletics.yaml
-chicago-grey-sox.yaml      philadelphia-phillies.yaml
-cincinnati-reds.yaml       pittsburgh-pirates.yaml
-cleveland-indians.yaml     san-diego-padres.yaml
-colorado-rockies.yaml      seattle-mariners.yaml
-detroit-tigers.yaml        st-louis-cardinals.yaml
-houston-astros.yaml        tampa-bay-rays.yaml
-kansas-city-royals.yaml    texas-rangers.yaml
-los-angeles-angels.yaml    toronto-blue-jays.yaml
-los-angeles-dodgers.yaml   washington-nationals.yaml
-miami-marlins.yaml```
-
-You may see more files than what is shown here. It's ok! There are also files in other folders in `zg-tutorial` itself.
-This, too, is ok.
-
-
-```shell
-zimport --database mlb.db --dir $(pwd)
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/baltimore-orioles.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/kansas-city-royals.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/los-angeles-angels.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/miami-marlins.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/milwaukee-brewers.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/seattle-mariners.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/arizona-diamondbacks.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/st-louis-cardinals.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/houston-astros.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/oakland-athletics.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/boston-red-sox.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/new-york-yankees.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/pittsburgh-pirates.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/detroit-tigers.yaml
-Importing /Users/gkt/Work/zg-tutorial/zettels/baseball/cincinnati-reds.yaml
-[...]
+(zenv) $ zettel --file template.yaml --id tutorial --name id timestamp
 ```
 
-What you see will differ slightly. Where you see `/Users/gkt/Work`, you are likely to see the path to your own checkout directory.
+To serialize cards rather assigning a timestamp to them, use the `--counter` option:
 
-Let's look at one of these zettels.
+```shell
+(zenv) $ zettel --file template.yaml --id tutorial --counter tutorial --name id counter
+```
+
+This command initiates a count of cards with the `id` 'tutorial'.
+The default number of digits is four;
+the count is maintained in a new binary file `.counter.dat`.
+The values `id`, `counter`, and `timestamp` can be combined in any order.
+
+## ZettelGeist fields
+
+The preceding section introduced the fields `title` and `note`.
+In this section we provide a full list of ZettelGeist fields and the operations that may be performed on them.
+
+For fields with a string value, the option `--set-<FIELD>` inputs a value for that field, as we saw in the previous section.
+For fields with a list value, use the `--append-<FIELD>` and place each value within quotes.
+Examples will be provided below for the relevant fields. 
+
+All fields are user-defined.
+We provide suggestions based on our own workflows.
+
+### `bibkey`
+
+(String.) 
+A unique identifier for the source from which you have extracted this note.
+Users of the [Better BibTex](https://retorque.re/zotero-better-bibtex/) extension for [Zotero](https://www.zotero.org/) may want to enter the Better BibTex Citation Key in this field.
+
+### `bibtex`
+
+A BibTex citation.
+This field is redundant if you manage your bibliography with Zotero and tie note-cards to Zotero items with Better BibTex Citation Keys in the field `bibkey`.
+<!-- ris, or inline (string) -->
+
+### `cite`
+
+This field has two child fields, `bibkey` (redundant with the field above) and `page`.
+Values must be supplied for both child fields and placed in quotes.
+For instance:
+
+```shell
+--set-cite "FoucaultArchaeologyKnowledgeDiscourse1982" "pp. 103-4"
+```
+
+When creating a template card, enter a dummy value for `page`:
+
+```shell
+--set-cite "FoucaultArchaeologyKnowledgeDiscourse1982" "p."
+```
+
+When calling a template card with the `--file` option, the following syntax will update `cite` values:
+
+```shell
+--set-cite "" "pp. 103-4"
+```
+
+This command retains the `bibkey` value in the input file but replaces the previous `page` value with "pp. 1-2".
+
+### `comment`
+
+(String.)
+Any comment you want to make about the zettel in general.
+
+### `dates`
+
+A `year` (string) and `era` (string) as a nested dictionary.
+Syntax follows `cite`.
+
+### `title`
+(String.)
+A human-readable title for a sequence of note cards. 
+We set this title in the template card for a source and retain it in all note cards on that source.
+
+### `tags`
+
+(List.) 
+One or more keywords.
+Use the option `--append-tags` and put each keyword within quotes. 
+For instance: `--append-tags "Charles Babbage" "Ada Lovelace" "Victorian Era"`.
+
+### `mentions`
+
+(List.)
+One or more mentions.
+Syntax follows `tags`.
+
+### `summary`
+
+(String.)
+A concise summary of the note (by convention).
+
+### `note`
+
+(String.)
+This is the core element of the note card.
+Usually it is a quotation extracted from the source and page identified in the `cite` field.
+
+### `url`
+
+(String.)
+Useful for bookmarking websites.
+
+# Retrieving cards
+
+The previous section has described `zettel`, the ZettelGeist tool for writing note cards.
+We now describe tools for selectively retrieving cards.
+`zcreate` creates a new empty database.
+`zimport` populates the database with note cards.
+`zfind` runs queries on the database and returns matching cards.
+
+## Synopsis
+
+```zcreate --database <NAME>.db```
+
+```zimport --database <NAME>.db --dir $(pwd)```
+
+```zfind --database <NAME>.db  --query-string 'FIELD:"VALUE"' ``` [*options*]
+
+## A tutorial
+
+To illustrate the function of these tools, we use sample zettels published 
+at https://github.com/ZettelGeist/zg-tutorial.git. 
+Download the repository with `git clone`:
+
+```shell
+$ git clone https://github.com/ZettelGeist/zg-tutorial.git
+```
+
+This creates a new directory `zg-tutorial`.
+Enter `zg-tutorial/zettels/baseball` and list its contents: 
+
+```shell
+$ cd zg-tutorial/zettels/baseball
+$ ls
+```
+
+<!-- the arguments passed to zimport capture all zetteln in working dir and subdirectories. To import baseball zetteln only, this operation must be performed from the baseball dir -->
+
+Use `cat` to take a look at one of the cards.
 
 ```yaml
 title: MLB Teams
@@ -187,109 +254,114 @@ cite:
   page: web page
 ```
 
-Each of these zettels contains some information one might typically place on a note card. In our view of the world, notes would include
-important basics. The note will often be one of the longer fields. It can be written using what is known as the YAML block style. This means
-that all lines of input are taken, provided they maintain the same indentation level and/or blank. Everything will be taken as input until
-the next field or end of file is found.
+### Creating a database
 
-Also shown here are how you can maintain a list of tags. The `tags` field allows you to specify one or more tags. While we hope one day to
-build an auto-classifier (someday, someday...), we find that we actually need to assign labels, especially in our own book project that is
-actually making use of these tools.
+We will now import the cards into a database.
+First, create a new database: 
 
-## Search Examples
-
-Searching is done (at present) using the `zfind` tool. This tool can only perform AND-style queries, but it will soon offer every conceivable possibility. This limitation is similar to what you find in systems like Gmail's search operators, but even Gmail allows for NOT terms.
-
-The `zfind` tool has options to search every field. Once a field matches, you can use the show options to project values from the Zettel. There is also a `--count` option to tell you how many Zettels matched a query.
-
-Find how many Zettels mention Chicago in the `summary` field:
-
+```shell
+(zenv) $ zcreate --database mlb.db
+Creating new database mlb.db
 ```
-zfind --database mlb.db --find-summary Chicago --count
+
+Next, populate the database: 
+
+```shell
+(zenv) $ zimport --database mlb.db --dir $(pwd)
+```
+
+We are now ready to run queries on the database and selectively retrieve cards from it.
+
+## Running queries
+
+Searching is done with the `zfind` tool.
+The option `--query-string` tells `zfind` what to look for.
+The options `--count` and `--show-<FIELD>` tell `zfind` what to do with matches:
+
+- `--count` counts the cards matching the search criteria and prints that number to standard output.
+- `--show-<FIELD>` prints the specified field to standard output.
+
+These output options may be combined. `--show-<FIELD>` can be repeated with different fields.
+
+The basic syntax of `--query-string` is `'KEY:"VALUE"'`.
+This syntax is illustrated in the following examples: 
+
+1. To find how many cards mention Chicago in the `summary` field
+
+```shell
+(zenv) $ zfind --database mlb.db --query-string 'summary:"Chicago"' --count
 2 Zettels matched search
 ```
 
-...and print the `summary and `filename` of the zettels:
+2. To print the matching summaries and filenames
 
-```
-zfind --database mlb.db --find-summary Chicago --count --show-filename
-filename:
-20170731132024-chicago-cubs.yaml
-
-----------------------------------------
+```shell
+(zenv) $ zfind --database mlb.db --query-string 'summary:"Chicago"' --show-filename --show-summary
+summary: Chicago White Sox
 
 filename:
-20170731155613-chicago-grey-sox.yaml
+/path/to/chicago-grey-sox.yaml
 
-----------------------------------------
+---
 
-2 Zettels matched search
-```
-
-...and show the `summary` about the teams:
-
-```
-zfind --database mlb.db --find-summary Chicago --count --show-filename --show-summary
-summary:
-Chicago Cubs
+summary: Chicago Cubs
 
 filename:
-20170731132024-chicago-cubs.yaml
+/path/to/chicago-cubs.yaml
 
-----------------------------------------
-
-summary:
-Chicago White Sox
-
-filename:
-20170731155613-chicago-grey-sox.yaml
-
-----------------------------------------
+---
 ```
 
-Find the terms MLB and Central in the `note` field. Upon finding a  match, show the `filename` and the `summary` fields.
+3. To find the phrase "Central division" in the `note` field and print the `summary` fields
 
-```
-zfind --database mlb.db --find-note "MLB Central" --show-filename --show-summary
-summary:
-Chicago Cubs
+```shell
+(zenv) $ zfind --database mlb.db --query-string 'note:"Central division"' --show-summary
+summary: Minnesota Twins
 
-filename:
-20170731132024-chicago-cubs.yaml
+---
 
-----------------------------------------
+summary: Pittsburgh Pirates
 
-summary:
-Cincinnati Reds
+---
 
-filename:
-20170731133642-cincinnati-reds.yaml
+summary: Cincinnati Reds
 
-----------------------------------------
+---
 
-summary:
-Pittsburgh Pirates
+summary: Detroit Tigers
 
-filename:
-20170731135121-pittsburgh-pirates.yaml
+---
 
-----------------------------------------
+summary: Cleveland Indians
 
-summary:
-St. Louis Cardinals
+---
 
-filename:
-20170731135823-st-louis-cardinals.yaml
+summary: St. Louis Cardinals
 
-----------------------------------------
-```
+---
 
-Find all zettels with Cubs mentioned in the `note` field:
+summary: Chicago Cubs
 
-```
-zfind --database mlb.db --find-note Cubs --show-note
+---
 
-note:
-The Chicago Cubs are an American professional baseball team based in Chicago, Illinois. The Cubs compete in Major League Baseball (MLB) as a member club of the National League (NL) Central division, where they are the defending World Series champions. The team plays its home games at Wrigley Field, located on the city's North Side. The Cubs are one of two major league teams in Chicago; the other, the Chicago White Sox, is a member of the American League (AL) Central division. The Cubs, first known as the White Stockings, was a founding member of the NL in 1876, becoming the Chicago Cubs in 1903.[2] The Cubs have appeared in a total of eleven World Series. The 1906 Cubs won 116 games, finishing 116–36 and posting a modern-era record winning percentage of .763, before losing the World Series to the Chicago White Sox by four games to two. The Cubs won back-to-back World Series championships in 1907 and 1908, becoming the first major league team to play in three consecutive World Series, and the first to win it twice. Most recently, the Cubs won the 2016 National League Championship Series and 2016 World Series, which ended a 71-year National League pennant drought and a 108-year World Series championship drought,
+summary: Kansas City Royals
+
+---
 ```
 
+4. To find all cards with Cubs mentioned in the `note` field and print that field
+
+```shell
+(zenv) $ zfind --database mlb.db --query-string 'note:"Cubs"' --show-note
+
+note: |
+  The Chicago Cubs are an American professional baseball team based in Chicago, Illinois. The Cubs compete in Major League Baseball (MLB) as a member club of the National League (NL) Central division, where they are the defending World Series champions. The team plays its home games at Wrigley Field, located on the city's North Side. The Cubs are one of two major league teams in Chicago; the other, the Chicago White Sox, is a member of the American League (AL) Central division. The Cubs, first known as the White Stockings, was a founding member of the NL in 1876, becoming the Chicago Cubs in 1903.[2] The Cubs have appeared in a total of eleven World Series. The 1906 Cubs won 116 games, finishing 116–36 and posting a modern-era record winning percentage of .763, before losing the World Series to the Chicago White Sox by four games to two. The Cubs won back-to-back World Series championships in 1907 and 1908, becoming the first major league team to play in three consecutive World Series, and the first to win it twice. Most recently, the Cubs won the 2016 National League Championship Series and 2016 World Series, which ended a 71-year National League pennant drought and a 108-year World Series championship drought,
+
+---
+```
+
+To save this output, redirect it from standard output to a file with `>`: 
+
+```shell
+(zenv) $ zfind --database mlb.db --query-string 'note:"Cubs"' --show-note > new-file.txt
+```

--- a/docs/install.md
+++ b/docs/install.md
@@ -6,90 +6,87 @@ permalink: /install/
 
 ## Prerequisites for All Installations
 
-Python 3 is _required_ to use ZettelGeist. We don't have resources to support multiple versions of Python.
+We support Unix/Linux, OS X using [Homebrew](https://brew.sh/), and Windows using [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
 
-We also recommend installing [bibutils](https://sourceforge.net/p/bibutils/home/Bibutils/) and 
-[sqlite3 with full-text search](https://www.sqlite.org/fts3.html). You may not need either of these, but should you
-run into issues, we may ask you to share some output from sqlite3 commands with us in your bug reports.
+Python 3 is required. We do not yet support multiple versions of Python.
 
-We only support Unix/Linux, OS X using [Homebrew](https://brew.sh/), and Windows using [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+We recommend installing [bibutils](https://sourceforge.net/p/bibutils/home/Bibutils/) and 
+[sqlite3 with full-text search](https://www.sqlite.org/fts3.html). 
+Neither is required, but we may ask you to share output from sqlite3 commands with us in bug reports.
 
-Please also note that ZettelGeist is not a web-based or GUI program (yet). This system is for people who _prefer_ working with plaintext, 
-text editors, and the command line. If this is not you, you will probably not like ZettelGeist and should proceed at your own peril.
+Please note that ZettelGeist is a command line application built for people who prefer working with the command line, plaintext, and text editors.
+If this is not you, you will probably not like ZettelGeist.
 
 ## Installation for General Users
 
-- Create a virtual environment for running ZettelGeist:
+1. Create a virtual environment for running ZettelGeist:
 
-  ```shell
-  python3 -m venv ~/zenv
-  ```
+   ```shell
+   $ python3 -m venv ~/zenv
+   ```
 
-  You can install your environment wherever you like, but we are going to assume `~/zenv` in the remaining discussion
-  and in our tutorial to _avoid_ having to talk about user-specific details.
+   You may install your environment wherever you like.
+   We will assume `~/zenv`.
 
-- Source the virtual environment
+2. Source the virtual environment
 
-  ```shell
-  . ~/zenv/bin/activate
-  ```
+   ```shell
+   $ . ~/zenv/bin/activate
+   ```
 
-- And _ensure_ that you are picking up the right `python` and `pip`.
+   The prompt will now be prefixed by `(zenv)`, the environment created in (1).
 
-  ```shell
-  ~ . ~/zenv/bin/activate
-  (zenv) ~ which pip
-  /Users/gkt/zenv/bin/pip
-  (zenv) ~ which python
-  /Users/gkt/zenv/bin/python
-  ```
+3. Confirm that you are picking up the right `python` and `pip`.
 
-  Your username would likely appear above instead of _gkt_, unless you share my initials.
+   ```shell
+   (zenv) $ which pip
+   /path/to/zenv/bin/pip
+   (zenv) $ which python
+   /path/to/zenv/bin/python
+   ```
 
-- Now install ZettelGeist
+  In place of `path/to/` you should see the absolute path to the environment created in (1). 
 
-  ```shell
-  (zenv) ~ pip install zettelgeist
-  Collecting zettelgeist
-    Downloading zettelgeist-0.12.2-py3-none-any.whl
-  Collecting tatsu (from zettelgeist)
-    Using cached TatSu-4.2.5-py2.py3-none-any.whl
-  Collecting PyYAML (from zettelgeist)
-  Installing collected packages: tatsu, PyYAML, zettelgeist
-  Successfully installed PyYAML-3.12 tatsu-4.2.5 zettelgeist-0.12.2
-  ```
+4. Install ZettelGeist
 
-  If you see `zettelgeist-<version>` in the above output, you should have a successful install. 
-  Let's verify:
+   ```shell
+   (zenv) $ pip install zettelgeist
+   Collecting zettelgeist
+     Downloading zettelgeist-0.12.2-py3-none-any.whl
+   Collecting tatsu (from zettelgeist)
+     Using cached TatSu-4.2.5-py2.py3-none-any.whl
+   Collecting PyYAML (from zettelgeist)
+   Installing collected packages: tatsu, PyYAML, zettelgeist
+   Successfully installed PyYAML-3.12 tatsu-4.2.5 zettelgeist-0.12.2
+   ```
+ 
+   If you see `zettelgeist-<version>` in the output, you should have a successful install. 
 
-  ```shell
-  (zenv) ~ which zcreate
-  /Users/gkt/zenv2/bin/zcreate
-  (zenv) ~ which zimport
-  /Users/gkt/zenv2/bin/zimport
-  (zenv) ~ which zquicksearch
-  /Users/gkt/zenv2/bin/zquicksearch
-  (zenv) ~ which zfilter
-  /Users/gkt/zenv2/bin/zfilter
-  (zenv) ~ which zettel
-  /Users/gkt/zenv2/bin/zettel
-  ```
+5. Verify the installation
 
+   ```shell
+   (zenv) $ which zcreate
+   /path/to/zenv/bin/zcreate
+   (zenv) $ which zimport
+   /path/to/zenv/bin/zimport
+   (zenv) $ which zfind
+   /path/to/zenv/bin/zfind
+   (zenv) $ which zfilter
+   /path/to/zenv/bin/zfilter
+   (zenv) $ which zettel
+   /path/to/zenv/bin/zettel
+   ```
 
-- And create your first zettel:
+You may now proceed to the page [Getting Started](/gs).
 
-  ```shell
-  zettel --set-title "My First Zettel" --set-summary "I feel empowered." --append-tags "Tutorial" "ZettelGeist" "Install"
-  title: My First Zettel
-  summary: I feel empowered.
-  tags:
-  - Tutorial
-  - ZettelGeist
-  - Install
-  ```
+To return to the system environment execute `deactivate`:
 
-- Then you should proceed to the [Getting Started](/gs) page.
+```
+(zenv) $ deactivate
+```
 
+<!--
 ## Developer Install
 
 Coming soon.
+-->

--- a/docs/install.md
+++ b/docs/install.md
@@ -78,7 +78,7 @@ If this is not you, you will probably not like ZettelGeist.
    /path/to/zenv/bin/zettel
    ```
 
-   You may now proceed to the page [Getting Started](/gs).
+   You may now proceed to the [User's Guide](/gs).
 
 <!--
 ## Developer Install

--- a/docs/install.md
+++ b/docs/install.md
@@ -35,6 +35,7 @@ If this is not you, you will probably not like ZettelGeist.
    ```
 
    The prompt will now be prefixed by `(zenv)`, the environment created in (1).
+   The command `deactivate` returns you to the system environment.
 
 3. Confirm that you are picking up the right `python` and `pip`.
 
@@ -45,7 +46,7 @@ If this is not you, you will probably not like ZettelGeist.
    /path/to/zenv/bin/python
    ```
 
-  In place of `path/to/` you should see the absolute path to the environment created in (1). 
+   In place of `path/to/` you should see the absolute path to the environment created in (1). 
 
 4. Install ZettelGeist
 
@@ -77,13 +78,7 @@ If this is not you, you will probably not like ZettelGeist.
    /path/to/zenv/bin/zettel
    ```
 
-You may now proceed to the page [Getting Started](/gs).
-
-To return to the system environment execute `deactivate`:
-
-```
-(zenv) $ deactivate
-```
+   You may now proceed to the page [Getting Started](/gs).
 
 <!--
 ## Developer Install


### PR DESCRIPTION
The diff is not useful because I have rewritten these two files end-to-end. 

I propose to re-title "Getting Started" as "User's Guide" and make this the primary reference document. In subsequent work I will comb through the tutorials (GDocs, Word, Terminal) and incorporate useful instruction into this document. 

For fuller description of changes, see individual commit messages.

The synopses need work. I am learning the conventions for that.